### PR TITLE
Fix/param import same names

### DIFF
--- a/simulator/runner/simulation_runner.py
+++ b/simulator/runner/simulation_runner.py
@@ -3,14 +3,14 @@ import logging
 from asyncio import get_event_loop, new_event_loop, set_event_loop
 from os import makedirs
 from os import path
-from os.path import basename
+import os.path
 from subprocess import PIPE, Popen
 
 from .config import SingularityConfig
 from .datastore import Datastore
 from ..utils.logging import RTLogging
 
-logger = logging.getLogger(basename(__file__).split(".")[0])
+logger = logging.getLogger(os.path.basename(__file__).split(".")[0])
 
 
 class AsyncRunner:

--- a/simulator/runner/simulation_runner.py
+++ b/simulator/runner/simulation_runner.py
@@ -2,8 +2,7 @@ import logging
 
 from asyncio import get_event_loop, new_event_loop, set_event_loop
 from os import makedirs
-from os import path
-import os.path
+import os
 from subprocess import PIPE, Popen
 
 from .config import SingularityConfig
@@ -93,8 +92,8 @@ class SimulationRunner(AsyncRunner):
         )
 
         datastore = Datastore(
-            path.join(output_folder, "simulation"),
-            path.join(
+            os.path.join(output_folder, "simulation"),
+            os.path.join(
                 output_folder,
                 "phantom",
                 "{}_phantom_merged_bundles.fib".format(run_name),
@@ -104,7 +103,7 @@ class SimulationRunner(AsyncRunner):
         )
 
         datastore.load_compartments(
-            path.join(output_folder, "phantom"), run_name, output_nifti
+            os.path.join(output_folder, "phantom"), run_name, output_nifti
         )
         datastore.stage_compartments(run_name)
 
@@ -136,17 +135,17 @@ class SimulationRunner(AsyncRunner):
 
         base_output_folder = output_folder
         output_folder = self._create_outputs(
-            path.join(output_folder, "phantom")
+            os.path.join(output_folder, "phantom")
         )
 
-        phantom_def = path.join(
+        phantom_def = os.path.join(
             phantom_infos["file_path"], phantom_infos["base_file"]
         )
 
         resolution = ",".join([str(r) for r in phantom_infos["resolution"]])
         spacing = ",".join([str(s) for s in phantom_infos["spacing"]])
         fiber_fraction = "rel" if relative_fiber_fraction else "abs"
-        out_name = path.join(
+        out_name = os.path.join(
             output_folder, "phantom, " "{}_phantom".format(run_name)
         )
 
@@ -159,7 +158,7 @@ class SimulationRunner(AsyncRunner):
 
         bind_paths = ",".join([phantom_infos["file_path"], output_folder])
         command = self._bind_singularity("phantom", bind_paths, arguments)
-        log_file = path.join(base_output_folder, "{}.log".format(run_name))
+        log_file = os.path.join(base_output_folder, "{}.log".format(run_name))
         self._run_command(command, log_file, "[PHANTOM]")
 
         loop_managed or self.stop()
@@ -181,18 +180,18 @@ class SimulationRunner(AsyncRunner):
         bind_paths = [] if bind_paths is None else bind_paths
         base_output_folder = output_folder
         output_folder = self._create_outputs(
-            path.join(output_folder, "simulation")
+            os.path.join(output_folder, "simulation")
         )
 
         name = "{}_simulation".format(run_name)
 
         bind_paths += [simulation_infos["file_path"], output_folder]
         bind_paths = ",".join(bind_paths)
-        ffp_file = path.join(
+        ffp_file = os.path.join(
             simulation_infos["file_path"], simulation_infos["param_file"]
         )
         extension = "nii.gz" if output_nifti else "nrrd"
-        out_name = path.join(output_folder, "{}.{}".format(name, extension))
+        out_name = os.path.join(output_folder, "{}.{}".format(name, extension))
 
         if not compartments_staged and compartment_maps is not None:
             datastore = Datastore(
@@ -207,7 +206,7 @@ class SimulationRunner(AsyncRunner):
         arguments = "-p {} -i {} -o {}".format(ffp_file, fibers_file, out_name)
 
         command = self._bind_singularity("diffusion mri", bind_paths, arguments)
-        log_file = path.join(base_output_folder, "{}.log".format(run_name))
+        log_file = os.path.join(base_output_folder, "{}.log".format(run_name))
         self._run_command(command, log_file, "[DIFFUSION MRI]")
 
         loop_managed or self.stop()

--- a/simulator/runner/simulation_runner.py
+++ b/simulator/runner/simulation_runner.py
@@ -65,7 +65,7 @@ class SimulationRunner(AsyncRunner):
         )
 
     def _create_outputs(self, path):
-        if not path.exists(path):
+        if not os.path.exists(path):
             makedirs(path, exist_ok=True)
 
         return path

--- a/simulator/runner/simulation_runner.py
+++ b/simulator/runner/simulation_runner.py
@@ -1,7 +1,8 @@
 import logging
 
 from asyncio import get_event_loop, new_event_loop, set_event_loop
-from os import makedirs, path
+from os import makedirs
+from os import path
 from os.path import basename
 from subprocess import PIPE, Popen
 

--- a/simulator/runner/simulation_runner.py
+++ b/simulator/runner/simulation_runner.py
@@ -64,7 +64,8 @@ class SimulationRunner(AsyncRunner):
             arguments,
         )
 
-    def _create_outputs(self, path):
+    @staticmethod
+    def _create_outputs(path):
         if not os.path.exists(path):
             makedirs(path, exist_ok=True)
 


### PR DESCRIPTION
The parameters `path` of the method `_create_outputs` of the class `SimulationRunner` of the source code file `simulation_runner.py` shadows the name of `os.path`, which is currently imported with the `import-form` statement.

https://github.com/AlexVCaron/voxsim/blob/76ca69902459e0d3dc830ea14635dd38e2951dd2/simulator/runner/simulation_runner.py#L73

The reference in the current fork of the original repository : 

https://github.com/benoit-dubreuil/voxsim/blob/bd10859860562c9e0f2948bdf75faa0837b8025b/simulator/runner/simulation_runner.py#L68