### PR TITLE
Fix/str join takes path

### DIFF
--- a/simulator/runner/legacy.py
+++ b/simulator/runner/legacy.py
@@ -73,7 +73,7 @@ class SimulationRunner:
             "{} run -B {} --app launch_mitk {} -p {} -i {} -o {} {}".format(
                 self._singularity_exec,
                 ",".join(
-                    [simulation_infos["file_path"], simulation_output_folder]
+                    [str(simulation_infos["file_path"]), str(simulation_output_folder)]
                 ),
                 self._singularity,
                 path.join(
@@ -149,9 +149,9 @@ class SimulationRunner:
                 self._singularity_exec,
                 ",".join(
                     [
-                        geometry_folder,
-                        simulation_infos["file_path"],
-                        simulation_output_folder,
+                        str(geometry_folder),
+                        str(simulation_infos["file_path"]),
+                        str(simulation_output_folder),
                     ]
                 ),
                 self._singularity,
@@ -231,7 +231,7 @@ class SimulationRunner:
         geometry_command = (
             "singularity run -B {} --app launch_voxsim {} -f {} -r {} "
             "-s {} -o {} --comp-map {} --quiet{}".format(
-                ",".join([self._geometry_path, geometry_output_folder]),
+                ",".join([str(self._geometry_path), str(geometry_output_folder)]),
                 self._singularity,
                 path.join(self._geometry_path, self._geometry_base_file),
                 ",".join([str(r) for r in self._geometry_resolution]),
@@ -248,9 +248,9 @@ class SimulationRunner:
                 "-p {} -i {} -o {} {}".format(
                     ",".join(
                         [
-                            self._simulation_path,
-                            geometry_output_folder,
-                            simulation_output_folder,
+                            str(self._simulation_path),
+                            str(geometry_output_folder),
+                            str(simulation_output_folder),
                         ]
                     ),
                     self._singularity,

--- a/simulator/runner/simulation_runner.py
+++ b/simulator/runner/simulation_runner.py
@@ -157,7 +157,7 @@ class SimulationRunner(AsyncRunner):
         if output_nifti:
             arguments += " --nii"
 
-        bind_paths = ",".join([phantom_infos["file_path"], output_folder])
+        bind_paths = ",".join([str(phantom_infos["file_path"]), str(output_folder)])
         command = self._bind_singularity("phantom", bind_paths, arguments)
         log_file = os.path.join(base_output_folder, "{}.log".format(run_name))
         self._run_command(command, log_file, "[PHANTOM]")
@@ -186,7 +186,7 @@ class SimulationRunner(AsyncRunner):
 
         name = "{}_simulation".format(run_name)
 
-        bind_paths += [simulation_infos["file_path"], output_folder]
+        bind_paths += [str(simulation_infos["file_path"]), str(output_folder)]
         bind_paths = ",".join(bind_paths)
         ffp_file = os.path.join(
             simulation_infos["file_path"], simulation_infos["param_file"]


### PR DESCRIPTION
`str.join` supports only strictly `str` parameters. Any other type results in an error, even though it might be string convertible, such as `pathlib.Path`.